### PR TITLE
Fix typos in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ Following release are included:
 * Release 76 dated 2020.06.12.
 * Release 77 dated 2020.08.10.
 
-Code which generrates these files can be founde here: https://github.com/UniCourt/cic-beautify-state-codes
+Code which generates these files can be found here: https://github.com/UniCourt/cic-beautify-state-codes
 
 Original RTF files can be foud here: https://archive.org/download/gov.ga.ocga.2018

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Code Improvement Commission - structured HTML State Codes of Georgia (GA)
 
 This repository was created by UniCourt on behalf of [Public.Resource.Org](https://public.resource.org/). All this work is in the public domain and there are NO RIGHTS RESERVED.
 
-Following release are included:
+Following releases are included:
 
 * Release 70 dated 2018.12.01.
 * Release 71 dated 2019.03.05.


### PR DESCRIPTION
Just fixes a couple of small typos:

founde -> found
generrates -> generates
release are -> releases are

Thanks so much for doing this, everyone!